### PR TITLE
fix(buffer): Expand `~` and `$VAR` in `file_pattern` before building Vim regex

### DIFF
--- a/lua/mado-scratch/buffer.lua
+++ b/lua/mado-scratch/buffer.lua
@@ -47,6 +47,11 @@ end
 ---@param pattern string -- Pattern with %d placeholder
 ---@return integer | nil -- Index number, or nil if not found
 local function extract_index_from_name(name, pattern)
+  -- Expand ~ and $VAR to absolute path to avoid E33 (~ is special in Vim regex: last substitute string)
+  -- and to correctly match buffer names which are stored as absolute paths.
+  -- Protect %d with a control character placeholder since vim.fn.expand() interprets % as a Vim modifier.
+  pattern = vim.fn.expand(pattern:gsub('%%d', '\x01')):gsub('\x01', '%%d')
+
   -- Replace %d with a unique placeholder that won't appear in paths
   local temp_placeholder = '__INDEX__'
   local protected_pattern = pattern:gsub('%%d', temp_placeholder)

--- a/lua/mado-scratch/buffer.lua
+++ b/lua/mado-scratch/buffer.lua
@@ -49,8 +49,9 @@ end
 local function extract_index_from_name(name, pattern)
   -- Expand ~ and $VAR to absolute path to avoid E33 (~ is special in Vim regex: last substitute string)
   -- and to correctly match buffer names which are stored as absolute paths.
-  -- Protect %d with a control character placeholder since vim.fn.expand() interprets % as a Vim modifier.
-  pattern = vim.fn.expand(pattern:gsub('%%d', '\x01')):gsub('\x01', '%%d')
+  -- Protect %d with a sentinel placeholder since vim.fn.expand() interprets % as a Vim modifier.
+  local percent_d_sentinel = '__MADO_SCRATCH_PERCENT_D__'
+  pattern = vim.fn.expand(pattern:gsub('%%d', percent_d_sentinel)):gsub(percent_d_sentinel, '%%d')
 
   -- Replace %d with a unique placeholder that won't appear in paths
   local temp_placeholder = '__INDEX__'


### PR DESCRIPTION
## Summary

- Fix `E33: No previous substitute regular expression` error thrown when `file_pattern` contains `~` (e.g. `~/tmp/scratch-%d`)

## Changes

- In `extract_index_from_name`, expand path variables (`~`, `$VAR`) via `vim.fn.expand()` before building the Vim regex
- Protect `%d` format specifier with a SOH control character placeholder (`\x01`) to prevent `vim.fn.expand()` from interpreting `%` as a Vim filename modifier

## Root Cause

In Vim regex (used by `vim.fn.matchlist()`), `~` is a special character that matches the last substitute replacement string. When no previous `:s` command has been run, this causes `E33`. The bug was latent until a user configured `file_pattern` with a `~`-prefixed path.